### PR TITLE
add methods for backwards compatibility

### DIFF
--- a/src/Ibex.java.in
+++ b/src/Ibex.java.in
@@ -151,6 +151,21 @@ public class Ibex {
 	 */
 	public native int contract(int i, double bounds[], int reif, double rel_eps);
 
+    /**
+     * Same as contract(int, double bounds[], int reif, double rel_eps) with reif=TRUE.
+     */
+    public native int contract(int i, double bounds[], double rel_eps);
+
+    /**
+     * Same as contract(int, double bounds[], int reif, double rel_eps) with rel_eps=RATIO.
+     */
+    public native int contract(int i, double bounds[], int reify);
+
+    /**
+     * Same as contract(int, double bounds[], int reif, double rel_eps) with reif=TRUE and rel_eps=RATIO.
+     */
+    public native int contract(int i, double bounds[]);
+
 	/**
 	 * Inflate a point to a box with respect to a constraint or its negation.
 	 *
@@ -200,11 +215,6 @@ public class Ibex {
 	 *   NOT_BUILT       - Object not built (build() must be called before)
 	 */
 	public native int inflate(int i, double p[], double bounds[], boolean in);
-
-	/**
-	 * Same as contract(int, double bounds[], int reif) with reif=TRUE.
-	 */
-	public native int contract(int i, double bounds[], double rel_eps);
 
 	/**
 	 * Let IBEX terminates the solving process for the CSP, once all the integer

--- a/src/ibex_Java.cpp.in
+++ b/src/ibex_Java.cpp.in
@@ -392,6 +392,14 @@ JNIEXPORT jint JNICALL Java_@JAVA_SIGNATURE@_Ibex_contract__I_3DD(JNIEnv* env, j
 	return Java_@JAVA_SIGNATURE@_Ibex_contract__I_3DID(env,obj,n,_d,1,rel_eps);
 }
 
+JNIEXPORT jint JNICALL Java_@JAVA_SIGNATURE@_Ibex_contract__I_3DI(JNIEnv* env, jobject obj, jint n, jdoubleArray _d, jint reif) {
+	return Java_@JAVA_SIGNATURE@_Ibex_contract__I_3DID(env,obj,n,_d,reif,EPS_CONTRACT);
+}
+
+JNIEXPORT jint JNICALL Java_@JAVA_SIGNATURE@_Ibex_contract__I_3D(JNIEnv* env, jobject obj, jint n, jdoubleArray _d) {
+	return Java_@JAVA_SIGNATURE@_Ibex_contract__I_3DID(env,obj,n,_d,1,EPS_CONTRACT);
+}
+
 JNIEXPORT jint JNICALL Java_@JAVA_SIGNATURE@_Ibex_inflate(JNIEnv* env, jobject obj, jint n, jdoubleArray _din, jdoubleArray _d, jboolean in) {
 
 	Instance& inst = *get_instance(env,obj);


### PR DESCRIPTION
I'm proposing to keep backwards compatibility for the contraction method.